### PR TITLE
Modified the `getEmailAddress` function to consistently return an arr…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,21 +109,16 @@ function getCharset(contentType: string) {
 /**
  * Gets name and e-mail address from a string, e.g. 'PayPal' <noreply@paypal.com> => { name: 'PayPal', email: 'noreply@paypal.com' }
  * @param {String} raw
- * @returns { EmailAddress | EmailAddress[] | null}
+ * @returns {EmailAddress[]}
  */
-function getEmailAddress(rawStr: string): EmailAddress | EmailAddress[] | null {
+function getEmailAddress(rawStr: string): EmailAddress[] {
+	const addresses: EmailAddress[] = [];
 	const raw = unquoteString(rawStr);
 	const parseList = addressparser(raw);
-	const list = parseList.map((v) => ({ name: v.name, email: v.address }) as EmailAddress);
-
-	//Return result
-	if (list.length === 0) {
-		return null; //No e-mail address
+	for (const v of parseList) {
+		addresses.push({ name: v.name, email: v.address } as EmailAddress);
 	}
-	if (list.length === 1) {
-		return list[0]; //Only one record, return as object, required to preserve backward compatibility
-	}
-	return list; //Multiple e-mail addresses as array
+	return addresses; //Multiple e-mail addresses as array
 }
 
 /**

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -21,9 +21,9 @@ export interface ParsedEml {
 export interface EmlContent {
 	date: Date;
 	subject: string;
-	from: EmailAddress | EmailAddress[] | null;
-	to: EmailAddress | EmailAddress[] | null;
-	cc?: EmailAddress | EmailAddress[] | null;
+	from: EmailAddress[];
+	to: EmailAddress[];
+	cc?: EmailAddress[];
 	headers: EmlHeaders;
 	multipartAlternative?: {
 		'Content-Type': string;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -62,14 +62,14 @@ describe('Email Utility Functions', () => {
 
     describe('getEmailAddress', () => {
         it('should parse a simple email string', () => {
-            expect(getEmailAddress('"Test User" <test@example.com>')).toEqual({ name: 'Test User', email: 'test@example.com' });
+            expect(getEmailAddress('"Test User" <test@example.com>')).toEqual([{ name: 'Test User', email: 'test@example.com' }]);
         });
 
         it('should parse an email string with no name', () => {
-            expect(getEmailAddress('<test@example.com>')).toEqual({ name: '', email: 'test@example.com' });
+            expect(getEmailAddress('<test@example.com>')).toEqual([{ name: '', email: 'test@example.com' }]);
         });
         it('should parse an email string that is just an email', () => {
-            expect(getEmailAddress('test@example.com')).toEqual({ name: '', email: 'test@example.com' });
+            expect(getEmailAddress('test@example.com')).toEqual([{ name: '', email: 'test@example.com' }]);
         });
 
         it('should parse multiple email addresses', () => {
@@ -80,7 +80,7 @@ describe('Email Utility Functions', () => {
         });
 
         it('should return null for an empty string', () => {
-            expect(getEmailAddress('')).toBeNull();
+            expect(getEmailAddress('')).toEqual([]);
         });
     });
 
@@ -349,9 +349,9 @@ This is the plain text body of the email.\r\n`;
 
         expect(result.date).toEqual(new Date('Mon, 23 Sep 2024 10:00:00 +0000'));
         expect(result.subject).toBe('Test Subject');
-        expect(result.from).toEqual({ name: 'Sender', email: 'sender@example.com' });
-        expect(result.to).toEqual({ name: 'Receiver', email: 'receiver@example.com' });
-        expect(result.cc).toEqual({ name: 'Carbon Copy', email: 'cc@example.com' });
+        expect(result.from).toEqual([{ name: 'Sender', email: 'sender@example.com' }]);
+        expect(result.to).toEqual([{ name: 'Receiver', email: 'receiver@example.com' }]);
+        expect(result.cc).toEqual([{ name: 'Carbon Copy', email: 'cc@example.com' }]);
         expect(result.html).toBeUndefined();
         expect(result.attachments).toBeUndefined();
     });


### PR DESCRIPTION
…ay of `EmailAddress` rather than allowing for a single object or null, in line with updates to the `EmlContent` interface which now sets `from`, `to`, and `cc` fields strictly as arrays. Updated relevant unit tests in `index.test.ts` to reflect these changes, ensuring consistent outputs across various scenarios, including tests for empty strings returning empty arrays instead of null.